### PR TITLE
#6 catch bad response from switch

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -190,6 +190,8 @@ class ProcurveDriver(NetworkDriver):
         # Check if system supports the command
         if 'No such name.' in output:
             return {}
+        elif 'not translate variable' in output:
+            return {}
 
         return output.split(' = ')[1].strip()
 


### PR DESCRIPTION
e.g.: Cannot translate variable lldpRemSysDesc.0.A13.1.