### PR TITLE
fix error when ChassisId is truncated

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -391,6 +391,7 @@ class ProcurveDriver(NetworkDriver):
             "PortType": "lldpRemPortIdSubtype",
             "PortDescr": "lldpRemPortDesc",
             "SysName": "lldpRemSysName",
+            "ChassisId": "lldpRemChassisId",
         }
 
         key_porttype_table = {


### PR DESCRIPTION
Fix #15 (get_lldp_neighbors fails when ChassisId is truncated)