### PR TITLE
add field for remote system mgmt ip in lldp dict

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -362,6 +362,7 @@ class ProcurveDriver(NetworkDriver):
                     "remote_system_name": lldp_fields["SysName"],
                     "remote_system_description": lldp_fields["SystemDescr"],
                     "remote_system_capab": lldp_fields["SystemCapabilitiesSupported"],
+                    "remote_system_mgmt_ip": lldp_fields["AdmMgmtAddress"],
                     "remote_system_enable_capab": lldp_fields[
                         "SystemCapabilitiesEnabled"
                     ],


### PR DESCRIPTION
get_lldp_neighbors_detail() returns  dictionary of all the lldp neighbors on a switch. However, it doesn't have remote system's management ip. This will come in handy when you are building a network topology.

We already receive the remote system's mgmt ip from _lldp_detail_parser(), so this pull request is to just add a key value pair for mgmt ip.