### PR TITLE
adding read_timeout_override and session_log optional_args for netmiko

### DIFF
--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -69,7 +69,8 @@ class ProcurveDriver(NetworkDriver):
             "alt_host_keys": False,
             "alt_key_file": "",
             "ssh_config_file": None,
-            "session_log": None
+            "session_log": None,
+            "read_timeout_override": None,
         }
 
         # Build dict of any optional Netmiko args

--- a/napalm_procurve/procurve.py
+++ b/napalm_procurve/procurve.py
@@ -69,6 +69,7 @@ class ProcurveDriver(NetworkDriver):
             "alt_host_keys": False,
             "alt_key_file": "",
             "ssh_config_file": None,
+            "session_log": None
         }
 
         # Build dict of any optional Netmiko args


### PR DESCRIPTION
Fixes https://github.com/ixs/napalm-procurve/issues/31

Also adding `session_log` option